### PR TITLE
feat: add tan method 7 support

### DIFF
--- a/packages/fints/src/segments/hitan.ts
+++ b/packages/fints/src/segments/hitan.ts
@@ -4,11 +4,13 @@ import { SegmentClass } from "./segment";
 export class HITANProps {
     public segNo: number;
     public process: number;
-    public transactionHash: string;
-    public transactionReference: string;
-    public challengeText: string;
-    public challengeMediaType: string;
-    public challengeMedia: Buffer;
+    public transactionHash?: string;
+    public transactionReference?: string;
+    public challengeText?: string;
+    public challengeMediaType?: string;
+    public challengeMedia?: Buffer;
+    public challengeValidUntil?: Date;
+    public tanMedium?: string;
 }
 
 export class HITAN extends SegmentClass(HITANProps) {
@@ -19,17 +21,49 @@ export class HITAN extends SegmentClass(HITANProps) {
     }
 
     protected deserialize(input: string[][]) {
-        if (![6].includes(this.version)) {
+        if (![6, 7].includes(this.version)) {
             throw new Error(`Unimplemented TAN method version ${this.version} encountered.`);
         }
-        const [[process], [transactionHash], [transactionReference], [challengeText], ...challengeHhdUc] = input;
-
-        this.process = Parse.num(process as string);
-        this.transactionHash = transactionHash;
-        this.transactionReference = transactionReference;
-        this.challengeText = challengeText;
-        if (challengeHhdUc.length > 0) {
-            [this.challengeMediaType, this.challengeMedia] = Parse.challengeHhdUc(challengeHhdUc);
+        if (this.version === 6) {
+            const [[process], [transactionHash], [transactionReference], [challengeText], ...challengeHhdUc] = input;
+            this.process = Parse.num(process as string);
+            this.transactionHash = transactionHash;
+            this.transactionReference = transactionReference;
+            this.challengeText = challengeText;
+            if (challengeHhdUc.length > 0) {
+                [this.challengeMediaType, this.challengeMedia] = Parse.challengeHhdUc(challengeHhdUc);
+            }
+        } else {
+            const [
+                [process],
+                transactionHash,
+                transactionReference,
+                challengeText,
+                challengeHhdUc,
+                challengeValidUntil,
+                tanMedium,
+            ] = input;
+            this.process = Parse.num(process as string);
+            if (transactionHash) { this.transactionHash = transactionHash[0]; }
+            if (transactionReference) { this.transactionReference = transactionReference[0]; }
+            if (challengeText) { this.challengeText = challengeText[0]; }
+            if (challengeHhdUc && challengeHhdUc.length > 0) {
+                [this.challengeMediaType, this.challengeMedia] = Parse.challengeHhdUc(challengeHhdUc as string[][]);
+            }
+            if (challengeValidUntil && challengeValidUntil.length > 0) {
+                const [dateStr, timeStr] = challengeValidUntil as string[];
+                if (dateStr) {
+                    const date = Parse.date(dateStr);
+                    if (timeStr) {
+                        const hours = Number(timeStr.substr(0, 2));
+                        const minutes = Number(timeStr.substr(2, 2));
+                        const seconds = Number(timeStr.substr(4, 2));
+                        date.setHours(hours, minutes, seconds);
+                    }
+                    this.challengeValidUntil = date;
+                }
+            }
+            if (tanMedium) { this.tanMedium = tanMedium[0]; }
         }
     }
 }

--- a/packages/fints/src/segments/hitans.ts
+++ b/packages/fints/src/segments/hitans.ts
@@ -19,7 +19,7 @@ export class HITANS extends SegmentClass(HITANSProps) {
     protected serialize(): string[][] { throw new Error("Not implemented."); }
 
     protected deserialize(input: string[][]) {
-        if (![1, 2, 3, 4, 5, 6].includes(this.version)) {
+        if (![1, 2, 3, 4, 5, 6, 7].includes(this.version)) {
             throw new Error(`Unimplemented TAN method version ${this.version} encountered.`);
         }
         const [

--- a/packages/fints/src/tan-method.ts
+++ b/packages/fints/src/tan-method.ts
@@ -129,12 +129,50 @@ tanMethodArgumentMap.set(6, [
     "supportedMediaNumber",
 ]);
 
+tanMethodArgumentMap.set(7, [
+    "securityFunction",
+    "tanProcess",
+    "techId",
+    "zkaId",
+    "zkaVersion",
+    "name",
+    "maxLengthInput",
+    "allowedFormat",
+    "textReturnvalue",
+    "maxLengthReturnvalue",
+    "numberOfSupportedLists",
+    "multiple",
+    "tanTimeDialogAssociation",
+    "tanDialogOptions",
+    "tanListNumberRequired",
+    "cancellable",
+    "smsChargeAccountRequired",
+    "principalAccountRequired",
+    "challengeClassRequired",
+    "challengeValueRequired",
+    "challengeStructured",
+    "initializationMode",
+    "supportedMediaNumber",
+    "hhdUcRequired",
+    "activeTanMedia",
+    "decoupledMaxStatusRequests",
+    "decoupledWaitBeforeFirstStatusRequest",
+    "decoupledWaitBetweenStatusRequests",
+    "decoupledManualConfirmationAllowed",
+    "decoupledAutoConfirmationAllowed",
+]);
+
 export class TanMethod {
     public allowedFormat?: string;
     public cancellable?: boolean;
     public challengeClassRequired?: boolean;
     public challengeValueRequired?: boolean;
     public challengeStructured?: boolean;
+    public decoupledAutoConfirmationAllowed?: boolean;
+    public decoupledManualConfirmationAllowed?: boolean;
+    public decoupledMaxStatusRequests?: number;
+    public decoupledWaitBeforeFirstStatusRequest?: number;
+    public decoupledWaitBetweenStatusRequests?: number;
     public descriptionRequired?: string;
     public hhdUcRequired?: boolean;
     public initializationMode?: string;
@@ -142,12 +180,14 @@ export class TanMethod {
     public maxLengthReturnvalue?: number;
     public multiple?: boolean;
     public name?: string;
+    public activeTanMedia?: number;
     public numberOfSupportedLists?: number;
     public principalAccountRequired?: boolean;
     public securityFunction?: string;
     public smsChargeAccountRequired?: boolean;
     public supportedMediaNumber?: number;
     public tanListNumberRequired?: boolean;
+    public tanDialogOptions?: string;
     public tanProcess?: string;
     public tanTimeDialogAssociation?: string;
     public techId?: string;
@@ -168,6 +208,26 @@ export class TanMethod {
         this.challengeClassRequired = Parse.bool(map.get("challengeClassRequired"));
         this.challengeValueRequired = Parse.bool(map.get("challengeValueRequired"));
         this.challengeStructured = Parse.bool(map.get("challengeStructured"));
+        const decoupledAuto = map.get("decoupledAutoConfirmationAllowed");
+        if (typeof decoupledAuto !== "undefined") {
+            this.decoupledAutoConfirmationAllowed = Parse.bool(decoupledAuto);
+        }
+        const decoupledManual = map.get("decoupledManualConfirmationAllowed");
+        if (typeof decoupledManual !== "undefined") {
+            this.decoupledManualConfirmationAllowed = Parse.bool(decoupledManual);
+        }
+        const decoupledMax = map.get("decoupledMaxStatusRequests");
+        if (typeof decoupledMax !== "undefined") {
+            this.decoupledMaxStatusRequests = Parse.num(decoupledMax);
+        }
+        const decoupledWaitFirst = map.get("decoupledWaitBeforeFirstStatusRequest");
+        if (typeof decoupledWaitFirst !== "undefined") {
+            this.decoupledWaitBeforeFirstStatusRequest = Parse.num(decoupledWaitFirst);
+        }
+        const decoupledWaitBetween = map.get("decoupledWaitBetweenStatusRequests");
+        if (typeof decoupledWaitBetween !== "undefined") {
+            this.decoupledWaitBetweenStatusRequests = Parse.num(decoupledWaitBetween);
+        }
         this.descriptionRequired = map.get("descriptionRequired");
         this.hhdUcRequired = Parse.bool(map.get("hhdUcRequired"));
         this.initializationMode = map.get("initializationMode");
@@ -175,6 +235,10 @@ export class TanMethod {
         this.maxLengthReturnvalue = Parse.num(map.get("maxLengthReturnvalue"));
         this.multiple = Parse.bool(map.get("multiple"));
         this.name = map.get("name");
+        const activeTanMedia = map.get("activeTanMedia");
+        if (typeof activeTanMedia !== "undefined") {
+            this.activeTanMedia = Parse.num(activeTanMedia);
+        }
         this.numberOfSupportedLists = Parse.num(map.get("numberOfSupportedLists"));
         this.principalAccountRequired = map.get("principalAccountRequired") === "2";
         this.securityFunction = map.get("securityFunction");
@@ -182,6 +246,10 @@ export class TanMethod {
         this.supportedMediaNumber = Parse.num(map.get("supportedMediaNumber"));
         this.tanListNumberRequired = Parse.bool(map.get("tanListNumberRequired"));
         this.tanProcess = map.get("tanProcess");
+        const tanDialogOptions = map.get("tanDialogOptions");
+        if (typeof tanDialogOptions !== "undefined") {
+            this.tanDialogOptions = tanDialogOptions;
+        }
         this.tanTimeDialogAssociation = map.get("tanTimeDialogAssociation");
         this.techId = map.get("techId");
         this.textReturnvalue = map.get("textReturnvalue");


### PR DESCRIPTION
## Summary
- add TAN procedure 7 mapping with decoupled parameters
- handle HITANS/HITAN segment version 7 parsing

## Testing
- `npm run lint`
- `cd packages/fints && npm test`


------
https://chatgpt.com/codex/tasks/task_b_689462edfb5483318ec67390a3292ef3