### PR TITLE
Add parser and dialog tests to improve coverage

### DIFF
--- a/packages/fints/src/__tests__/test-dialog.ts
+++ b/packages/fints/src/__tests__/test-dialog.ts
@@ -1,0 +1,45 @@
+import { Dialog, DialogConfig } from "../dialog";
+import { Request } from "../request";
+import { TanRequiredError } from "../errors/tan-required-error";
+import { ResponseError } from "../errors/response-error";
+
+describe("Dialog", () => {
+    const baseConfig: DialogConfig = { blz: "1", name: "user", pin: "123", systemId: "0" } as any;
+
+    test("init adds HKTAN when version >= 6", async () => {
+        const connection = {
+            send: jest.fn().mockResolvedValue({
+                dialogId: "1",
+                success: true,
+                returnValues: () => new Map(),
+            }),
+        };
+        const dialog = new Dialog(baseConfig, connection as any);
+        dialog.hktanVersion = 6;
+        await dialog.init();
+        const req = connection.send.mock.calls[0][0];
+        const hasHKTAN = req.segments.some((seg: any) => seg.type === "HKTAN");
+        expect(hasHKTAN).toBe(true);
+    });
+
+    test("send throws ResponseError on failure", async () => {
+        const connection = {
+            send: jest.fn().mockResolvedValue({ success: false, returnValues: () => new Map(), errors: [] }),
+        };
+        const dialog = new Dialog(baseConfig, connection as any);
+        await expect(dialog.send(new Request(baseConfig))).rejects.toBeInstanceOf(ResponseError);
+    });
+
+    test("send throws TanRequiredError when TAN is required", async () => {
+        const hitan = { transactionReference: "ref", challengeText: "text", challengeMedia: Buffer.alloc(0) };
+        const connection = {
+            send: jest.fn().mockResolvedValue({
+                success: true,
+                returnValues: () => new Map([["0030", { message: "TAN required" }]]),
+                findSegment: () => hitan,
+            }),
+        };
+        const dialog = new Dialog(baseConfig, connection as any);
+        await expect(dialog.send(new Request(baseConfig))).rejects.toBeInstanceOf(TanRequiredError);
+    });
+});

--- a/packages/fints/src/__tests__/test-parse.ts
+++ b/packages/fints/src/__tests__/test-parse.ts
@@ -1,0 +1,45 @@
+import { Parse } from "../parse";
+import { Buffer } from "buffer";
+
+describe("Parse", () => {
+    test("bool", () => {
+        expect(Parse.bool("J")).toBe(true);
+        expect(Parse.bool("N")).toBe(false);
+    });
+
+    test("num", () => {
+        expect(Parse.num("1,23")).toBeCloseTo(1.23);
+        expect(Parse.num(undefined as any)).toBeUndefined();
+    });
+
+    test("dig", () => {
+        expect(Parse.dig("00012")).toBe(12);
+        expect(Parse.dig("0")).toBe(0);
+    });
+
+    test("date", () => {
+        expect(Parse.date("20191224")).toEqual(new Date("2019-12-24T00:00:00.000Z"));
+    });
+
+    test("xml", () => {
+        expect(Parse.xml("<root><child>1</child></root>")).toEqual({ root: { child: 1 } });
+    });
+
+    test("challengeHhdUc", () => {
+        const mediaType = "image/png";
+        const data = Buffer.from([1, 2, 3]);
+        const buffer = Buffer.alloc(2 + mediaType.length + 2 + data.length);
+        buffer.writeUIntBE(mediaType.length, 0, 2);
+        buffer.write(mediaType, 2, mediaType.length, "utf8");
+        buffer.writeUIntBE(data.length, 2 + mediaType.length, 2);
+        data.copy(buffer, 2 + mediaType.length + 2);
+        const latin1 = buffer.toString("latin1");
+        const [mt, img] = Parse.challengeHhdUc([[latin1]]);
+        expect(mt).toBe(mediaType);
+        expect(img).toEqual(data);
+
+        const [emptyType, emptyBuf] = Parse.challengeHhdUc(undefined as any);
+        expect(emptyType).toBe("");
+        expect(emptyBuf).toEqual(Buffer.alloc(0));
+    });
+});


### PR DESCRIPTION
## Summary
- test Parse utility functions including challengeHhdUc and XML parsing
- cover Dialog init and error branches (HKTAN segment, ResponseError, TanRequiredError)

## Testing
- `cd packages/fints && npm test`

------
https://chatgpt.com/codex/tasks/task_b_6895f173738483318fba1aaae39cb8ed