### PR TITLE
Add holdings retrieval and balance commands

### DIFF
--- a/packages/fints-cli/README.md
+++ b/packages/fints-cli/README.md
@@ -12,6 +12,8 @@ A command line interface for communicating with [FinTS servers](https://www.hbci
 
 - Load list of accounts.
 - Load list of transactions in specified range.
+- Fetch the current balance for an account.
+- List holdings for depot accounts.
 
 ### List accounts
 
@@ -62,6 +64,56 @@ fint-cli list-accounts --url https://example.com/fints -n username -p 12345 -b 1
 
 ```
 ./fints-cli fetch-transactions --url http://example.com/fints -n username -p 12345 -b 12345678 -i DE111234567800000001 -s 2018-01-01 -e 2018-10-01
+```
+
+### Fetch current balance
+
+```
+  Fetch the current balance for a specified account.
+
+  USAGE
+
+    fints get-balance --url <url> --name <name> --pin <pin> --blz <blz> --iban <iban> [...options]
+
+  OPTIONS
+
+    -u, --url <url>   - Endpoint URL.
+    -n, --name <name> - Username used for connecting.
+    -p, --pin <pin>   - Pin used for connecting.
+    -b, --blz <blz>   - BLZ of the bank to connect to.
+    -d, --debug
+    -v, --verbose
+    -j, --json
+    -i, --iban <iban> - IBAN of the account to fetch.
+```
+
+```
+./fints-cli get-balance --url https://example.com/fints -n username -p 12345 -b 12345678 -i DE111234567800000001
+```
+
+### List holdings
+
+```
+  List the holdings of a depot account.
+
+  USAGE
+
+    fints list-holdings --url <url> --name <name> --pin <pin> --blz <blz> --iban <iban> [...options]
+
+  OPTIONS
+
+    -u, --url <url>   - Endpoint URL.
+    -n, --name <name> - Username used for connecting.
+    -p, --pin <pin>   - Pin used for connecting.
+    -b, --blz <blz>   - BLZ of the bank to connect to.
+    -d, --debug
+    -v, --verbose
+    -j, --json
+    -i, --iban <iban> - IBAN of the depot account to fetch.
+```
+
+```
+./fints-cli list-holdings --url https://example.com/fints -n username -p 12345 -b 12345678 -i DE111234567800000001
 ```
 
 ## Resources

--- a/packages/fints-cli/src/commands/get-balance.ts
+++ b/packages/fints-cli/src/commands/get-balance.ts
@@ -1,0 +1,26 @@
+import { PinTanClient } from "fints";
+import { setLevel } from "../logger";
+import { Command, command, metadata, option } from "clime";
+import { BaseConfig } from "../config";
+
+export class GetBalanceOptions extends BaseConfig {
+    @option({ required: true, flag: "i", description: "IBAN of the account to fetch." })
+    public iban: string;
+}
+
+@command({ description: "Fetch the current balance for a specified account." })
+export default class extends Command {
+    @metadata
+    public async execute({ verbose, json, serializer, iban, ...config }: GetBalanceOptions) {
+        setLevel(verbose);
+        const client = new PinTanClient(config);
+        const accounts = await client.accounts();
+        const account = accounts.find((current: any) => current.iban === iban);
+        if (!account) {
+            console.error("No account with specified iban found.");
+            return;
+        }
+        const balance = await (client as any).balance(account);
+        console.info(serializer(balance));
+    }
+}

--- a/packages/fints-cli/src/commands/list-holdings.ts
+++ b/packages/fints-cli/src/commands/list-holdings.ts
@@ -1,0 +1,31 @@
+import { PinTanClient } from "fints";
+import { setLevel } from "../logger";
+import { Command, command, metadata, option } from "clime";
+import { BaseConfig } from "../config";
+
+export class ListHoldingsOptions extends BaseConfig {
+    @option({ required: true, flag: "i", description: "IBAN of the account to fetch." })
+    public iban: string;
+}
+
+@command({ description: "List the holdings for a specified depot account." })
+export default class extends Command {
+    @metadata
+    public async execute({ verbose, json, serializer, iban, ...config }: ListHoldingsOptions) {
+        setLevel(verbose);
+        const client = new PinTanClient(config);
+        const accounts = await client.accounts();
+        const account = accounts.find((current: any) => current.iban === iban);
+        if (!account) {
+            console.error("No account with specified iban found.");
+            return;
+        }
+        try {
+            const holdings = await (client as any).holdings(account);
+            console.info(serializer(holdings));
+        } catch (error) {
+            const message = error instanceof Error ? error.message : String(error);
+            console.error(message);
+        }
+    }
+}

--- a/packages/fints/README.md
+++ b/packages/fints/README.md
@@ -34,6 +34,8 @@ console.info(statements); // List of all statements with transactions in specifi
 
 - Load list of accounts.
 - Load list of statements and transactions in specified range.
+- Fetch current account balances.
+- List depot holdings.
 - Parse statement [MT940](https://en.wikipedia.org/wiki/MT940) format.
 - Parse transaction descriptions.
 - Extract [reference tags](https://www.dzbank.de/content/dam/dzbank_de/de/home/produkte_services/Firmenkunden/PDF-Dokumente/transaction%20banking/elektronicBanking/SEPA-Belegungsregeln_MT940-DK_082016.~644b217ec96b35dfffcaf18dc2df800a.pdf) from transactions.
@@ -42,8 +44,6 @@ console.info(statements); // List of all statements with transactions in specifi
 
 ## Missing
 
-- Get current balance.
-- List holdings.
 - Initiate any kind of SEPA transfers or debits.
 
 ## Resources

--- a/packages/fints/src/__tests__/test-client-holdings.ts
+++ b/packages/fints/src/__tests__/test-client-holdings.ts
@@ -1,0 +1,84 @@
+import { Client } from "../client";
+import { Dialog } from "../dialog";
+import { HKWPD, HIWPD, Segment } from "../segments";
+import { Request } from "../request";
+import { SEPAAccount } from "../types";
+
+describe("Client holdings", () => {
+    const account: SEPAAccount = {
+        accountNumber: "123456789",
+        subAccount: "",
+        blz: "12345678",
+        iban: "DE111234567800000000",
+        bic: "GENODE00TES",
+    };
+
+    const holdingsSample = (isin: string, name: string) => `
+:16R:FIN
+:35B:ISIN ${isin}|/DE/ABC123|${name}
+:90B::MRKT//ACTU/EUR12,34
+:98A::PRIC//20240101
+:93B::AGGR//UNIT/1,0000
+:19A::HOLD//EUR12,34
+:16S:FIN
+-`;
+
+    class TestClient extends Client {
+        constructor(private readonly testDialog: any) {
+            super();
+        }
+
+        protected createDialog() {
+            return this.testDialog;
+        }
+
+        protected createRequest(_dialog: Dialog, segments: Segment<any>[], _tan?: string) {
+            return { segments } as unknown as Request;
+        }
+    }
+
+    test("aggregates holdings across touchdowns", async () => {
+        const response1 = {
+            getTouchdowns: jest.fn().mockReturnValue(new Map([["HKWPD", "TD123"]])),
+            findSegments: jest.fn((segmentClass: any) =>
+                segmentClass === HIWPD ? [new HIWPD({ segNo: 4, version: 6, holdings: holdingsSample("LU0000000001", "Fund A") })] : [],
+            ),
+        };
+        const response2 = {
+            getTouchdowns: jest.fn().mockReturnValue(new Map()),
+            findSegments: jest.fn((segmentClass: any) =>
+                segmentClass === HIWPD ? [new HIWPD({ segNo: 4, version: 6, holdings: holdingsSample("LU0000000002", "Fund B") })] : [],
+            ),
+        };
+        const send = jest.fn()
+            .mockResolvedValueOnce(response1)
+            .mockResolvedValueOnce(response2);
+        const dialog = {
+            hiwpdsVersion: 6,
+            sync: jest.fn().mockResolvedValue(undefined),
+            init: jest.fn().mockResolvedValue(undefined),
+            end: jest.fn().mockResolvedValue(undefined),
+            send,
+        };
+        const client = new TestClient(dialog);
+
+        const holdings = await client.holdings(account);
+
+        expect(dialog.sync).toHaveBeenCalled();
+        expect(dialog.init).toHaveBeenCalled();
+        expect(dialog.end).toHaveBeenCalled();
+        expect(send).toHaveBeenCalledTimes(2);
+        expect((send.mock.calls[0][0].segments[0] as HKWPD).touchdown).toBeUndefined();
+        expect((send.mock.calls[1][0].segments[0] as HKWPD).touchdown).toBe("TD123");
+        expect(holdings.map((item) => item.isin)).toEqual(["LU0000000001", "LU0000000002"]);
+    });
+
+    test("throws when holdings are not supported", async () => {
+        const dialog = {
+            hiwpdsVersion: 0,
+            sync: jest.fn().mockResolvedValue(undefined),
+        };
+        const client = new TestClient(dialog);
+        await expect(client.holdings(account)).rejects.toThrow("Holdings are not supported by this bank.");
+    });
+});

--- a/packages/fints/src/__tests__/test-mt535.ts
+++ b/packages/fints/src/__tests__/test-mt535.ts
@@ -1,0 +1,32 @@
+import { MT535Parser } from "../mt535";
+
+describe("MT535Parser", () => {
+    test("parses holdings from MT535 data", () => {
+        const parser = new MT535Parser();
+        const raw = `
+:16R:GENL
+:16S:GENL
+:16R:SUBSAFE
+:16R:FIN
+:35B:ISIN LU0635178014|/DE/ETF127|COMS.-MSCI EM.M.T.U.ETF I
+:90B::MRKT//ACTU/EUR38,82
+:98A::PRIC//20170428
+:93B::AGGR//UNIT/16,8211
+:19A::HOLD//EUR970,17
+:70E::HOLD//1STK|223,968293+EUR
+:16S:FIN
+:16S:SUBSAFE
+-`;
+        const result = parser.parse(raw.split(/\r?\n/));
+        expect(result).toHaveLength(1);
+        expect(result[0]).toMatchObject({
+            isin: "LU0635178014",
+            name: "COMS.-MSCI EM.M.T.U.ETF I",
+            marketPrice: 38.82,
+            currency: "EUR",
+            pieces: 16.8211,
+            totalValue: 970.17,
+        });
+        expect(result[0].valuationDate).toEqual(new Date(Date.UTC(2017, 3, 28)));
+    });
+});

--- a/packages/fints/src/dialog.ts
+++ b/packages/fints/src/dialog.ts
@@ -1,5 +1,5 @@
 import { Connection } from "./types";
-import { HKIDN, HKVVB, HKSYN, HKTAN, HKEND, HISALS, HIKAZS, HICDBS, HIUPD, HITANS, Segment } from "./segments";
+import { HKIDN, HKVVB, HKSYN, HKTAN, HKEND, HISALS, HIKAZS, HICDBS, HIUPD, HITANS, HIWPDS, Segment } from "./segments";
 import { Request } from "./request";
 import { Response } from "./response";
 import { TanMethod } from "./tan-method";
@@ -76,6 +76,11 @@ export class Dialog extends DialogConfig {
 
     public hktanVersion = 1;
     /**
+     * The server will only accept a certain version for the HIWPD segment.
+     * Stores the maximum supported version parsed during synchronization.
+     */
+    public hiwpdsVersion = 0;
+    /**
      * A list of supported SEPA pain-formats as configured by the server.
      */
     public painFormats: string[] = [];
@@ -112,6 +117,7 @@ export class Dialog extends DialogConfig {
         this.hisalsVersion = response.segmentMaxVersion(HISALS);
         this.hikazsVersion = response.segmentMaxVersion(HIKAZS);
         this.hicdbVersion = response.segmentMaxVersion(HICDBS);
+        this.hiwpdsVersion = response.segmentMaxVersion(HIWPDS);
         this.hktanVersion = response.segmentMaxVersion(HITANS);
         this.tanMethods = response.supportedTanMethods;
         this.painFormats = response.painFormats;

--- a/packages/fints/src/index.ts
+++ b/packages/fints/src/index.ts
@@ -5,6 +5,7 @@ export * from "./format";
 export * from "./http-connection";
 export * from "./logger";
 export * from "./mt940-86-structured";
+export * from "./mt535";
 export * from "./parse";
 export * from "./pin-tan-client";
 export * from "./request";

--- a/packages/fints/src/mt535.ts
+++ b/packages/fints/src/mt535.ts
@@ -1,0 +1,167 @@
+import { Holding } from "./types";
+
+interface FinancialInstrumentContext {
+    isin?: string;
+    name?: string;
+    marketPrice?: number;
+    currency?: string;
+    valuationDate?: Date;
+    pieces?: number;
+    totalValue?: number;
+    acquisitionPrice?: number;
+}
+
+/**
+ * Parser for holdings information encoded in MT535 statements.
+ */
+export class MT535Parser {
+    private readonly identification = /^:35B:ISIN\s(.*)\|(.*)\|(.*)$/;
+    private readonly marketPrice = /^:90B::MRKT\/\/ACTU\/([A-Z]{3})(\d*),{1}(\d*)$/;
+    private readonly priceDate = /^:98A::PRIC\/\/(\d*)$/;
+    private readonly pieces = /^:93B::AGGR\/\/UNIT\/(\d*),(\d*)$/;
+    private readonly totalValue = /^:19A::HOLD\/\/([A-Z]{3})(\d*),{1}(\d*)$/;
+    private readonly acquisitionPrice = /^:70E::HOLD\/\/\d*STK\|2(\d*?),{1}(\d*?)\+([A-Z]{3})$/;
+
+    public parse(lines: string[]): Holding[] {
+        if (!lines || lines.length === 0) {
+            return [];
+        }
+
+        const clauses = this.collapseMultilines(lines);
+        const financialInstrumentSegments = this.grabFinancialInstrumentSegments(clauses);
+        return financialInstrumentSegments.reduce<Holding[]>((result, segment) => {
+            const holding = this.parseFinancialInstrument(segment);
+            if (holding) {
+                result.push(holding);
+            }
+            return result;
+        }, []);
+    }
+
+    private parseFinancialInstrument(segment: string[]): Holding | undefined {
+        const context: FinancialInstrumentContext = {};
+        segment.forEach((clause) => this.parseClause(clause, context));
+        if (Object.keys(context).length === 0) {
+            return undefined;
+        }
+        return {
+            isin: context.isin,
+            name: context.name,
+            marketPrice: context.marketPrice,
+            currency: context.currency,
+            valuationDate: context.valuationDate,
+            pieces: context.pieces,
+            totalValue: context.totalValue,
+            acquisitionPrice: context.acquisitionPrice,
+        };
+    }
+
+    private parseClause(clause: string, context: FinancialInstrumentContext) {
+        let match = this.identification.exec(clause);
+        if (match) {
+            context.isin = match[1];
+            context.name = match[3];
+            return;
+        }
+
+        match = this.marketPrice.exec(clause);
+        if (match) {
+            context.currency = match[1];
+            context.marketPrice = this.parseDecimal(match[2], match[3]);
+            return;
+        }
+
+        match = this.priceDate.exec(clause);
+        if (match) {
+            context.valuationDate = this.parseDate(match[1]);
+            return;
+        }
+
+        match = this.pieces.exec(clause);
+        if (match) {
+            context.pieces = this.parseDecimal(match[1], match[2]);
+            return;
+        }
+
+        match = this.totalValue.exec(clause);
+        if (match) {
+            context.totalValue = this.parseDecimal(match[2], match[3]);
+            if (!context.currency) {
+                context.currency = match[1];
+            }
+            return;
+        }
+
+        match = this.acquisitionPrice.exec(clause);
+        if (match) {
+            context.acquisitionPrice = this.parseDecimal(match[1], match[2]);
+        }
+    }
+
+    private parseDecimal(integerPart: string, fractionPart: string): number {
+        const integer = integerPart || "0";
+        const fraction = fractionPart || "0";
+        return parseFloat(`${integer}.${fraction}`);
+    }
+
+    private parseDate(raw: string): Date | undefined {
+        if (!raw || raw.length !== 8) {
+            return undefined;
+        }
+        const year = Number(raw.substr(0, 4));
+        const month = Number(raw.substr(4, 2));
+        const day = Number(raw.substr(6, 2));
+        if (Number.isNaN(year) || Number.isNaN(month) || Number.isNaN(day)) {
+            return undefined;
+        }
+        return new Date(Date.UTC(year, month - 1, day));
+    }
+
+    private collapseMultilines(lines: string[]): string[] {
+        const clauses: string[] = [];
+        let previous = "";
+        for (const line of lines) {
+            if (line.startsWith(":")) {
+                if (previous !== "") {
+                    clauses.push(previous);
+                }
+                previous = line;
+            } else if (line.startsWith("-")) {
+                if (previous !== "") {
+                    clauses.push(previous);
+                }
+                clauses.push(line);
+                previous = "";
+            } else if (previous) {
+                previous += `|${line}`;
+            } else {
+                previous = line;
+            }
+        }
+        if (previous) {
+            clauses.push(previous);
+        }
+        return clauses;
+    }
+
+    private grabFinancialInstrumentSegments(clauses: string[]): string[][] {
+        const segments: string[][] = [];
+        let stack: string[] = [];
+        let withinInstrument = false;
+        clauses.forEach((clause) => {
+            if (clause.startsWith(":16R:FIN")) {
+                withinInstrument = true;
+                stack = [];
+            } else if (clause.startsWith(":16S:FIN")) {
+                if (withinInstrument) {
+                    segments.push(stack.slice());
+                }
+                withinInstrument = false;
+                stack = [];
+            } else if (withinInstrument) {
+                stack.push(clause);
+            }
+        });
+        return segments;
+    }
+}

--- a/packages/fints/src/segments/hiwpd.ts
+++ b/packages/fints/src/segments/hiwpd.ts
@@ -1,0 +1,21 @@
+import { SegmentClass } from "./segment";
+
+export class HIWPDProps {
+    public segNo: number;
+    public holdings: string;
+}
+
+/**
+ * HIWPD (Depotaufstellung rückmelden)
+ * Section D.6.1
+ */
+export class HIWPD extends SegmentClass(HIWPDProps) {
+    public type = "HIWPD";
+
+    protected serialize(): string[][] { throw new Error("Not implemented."); }
+
+    protected deserialize(input: string[][]) {
+        const group = input[0] || [];
+        this.holdings = group[0] || "";
+    }
+}

--- a/packages/fints/src/segments/hiwpds.ts
+++ b/packages/fints/src/segments/hiwpds.ts
@@ -1,0 +1,28 @@
+import { SegmentClass } from "./segment";
+import { Parse } from "../parse";
+
+export class HIWPDSProps {
+    public segNo: number;
+    public maxRequestCount?: number;
+    public minSignatures?: number;
+}
+
+/**
+ * HIWPDS (Depotaufstellung Parameter)
+ * Section D.6.1
+ */
+export class HIWPDS extends SegmentClass(HIWPDSProps) {
+    public type = "HIWPDS";
+
+    protected serialize(): string[][] { throw new Error("Not implemented."); }
+
+    protected deserialize(input: string[][]) {
+        const [ maxRequestsGroup = [], minSignaturesGroup = [] ] = input;
+        if (maxRequestsGroup[0]) {
+            this.maxRequestCount = Parse.num(maxRequestsGroup[0]);
+        }
+        if (minSignaturesGroup[0]) {
+            this.minSignatures = Parse.num(minSignaturesGroup[0]);
+        }
+    }
+}

--- a/packages/fints/src/segments/hkwpd.ts
+++ b/packages/fints/src/segments/hkwpd.ts
@@ -1,0 +1,40 @@
+import { Format } from "../format";
+import { SegmentClass } from "./segment";
+import { SEPAAccount } from "../types";
+import { COUNTRY_CODE } from "../constants";
+
+export class HKWPDProps {
+    public segNo: number;
+    public version: number;
+    public account: SEPAAccount;
+    public currency?: string;
+    public quality?: string;
+    public maxEntries?: number;
+    public touchdown?: string;
+}
+
+/**
+ * HKWPD (Depotaufstellung anfordern)
+ * Section D.6.1
+ */
+export class HKWPD extends SegmentClass(HKWPDProps) {
+    public type = "HKWPD";
+
+    protected serialize() {
+        const { version, account, currency, quality, maxEntries, touchdown } = this;
+        const { accountNumber, subAccount, blz } = account;
+        if (![5, 6].includes(version)) {
+            throw new Error(`Unsupported HKWPD version ${version}.`);
+        }
+        const serializedAccount = [accountNumber, subAccount, String(COUNTRY_CODE), blz];
+        return [
+            serializedAccount,
+            currency || Format.empty(),
+            quality || Format.empty(),
+            typeof maxEntries === "number" ? Format.num(maxEntries) : Format.empty(),
+            Format.stringEscaped(touchdown),
+        ];
+    }
+
+    protected deserialize() { throw new Error("Not implemented."); }
+}

--- a/packages/fints/src/segments/index.ts
+++ b/packages/fints/src/segments/index.ts
@@ -1,6 +1,8 @@
 export * from "./hibpa";
 export * from "./hicdb";
 export * from "./hicdbs";
+export * from "./hiwpd";
+export * from "./hiwpds";
 export * from "./hikaz";
 export * from "./hikazs";
 export * from "./hirmg";
@@ -15,6 +17,7 @@ export * from "./hkcdb";
 export * from "./hkend";
 export * from "./hkidn";
 export * from "./hkkaz";
+export * from "./hkwpd";
 export * from "./hksal";
 export * from "./hkspa";
 export * from "./hksyn";

--- a/packages/fints/src/types.ts
+++ b/packages/fints/src/types.ts
@@ -288,6 +288,44 @@ export interface Balance {
 }
 
 /**
+ * Represents a single security or holding entry returned by the bank.
+ */
+export interface Holding {
+    /**
+     * International Securities Identification Number of the holding.
+     */
+    isin?: string;
+    /**
+     * Human readable name of the holding.
+     */
+    name?: string;
+    /**
+     * Latest market price transmitted by the bank.
+     */
+    marketPrice?: number;
+    /**
+     * Currency in which all monetary values are denominated.
+     */
+    currency?: string;
+    /**
+     * Date of the valuation.
+     */
+    valuationDate?: Date;
+    /**
+     * Number of units held.
+     */
+    pieces?: number;
+    /**
+     * Total value of the position.
+     */
+    totalValue?: number;
+    /**
+     * Acquisition price communicated by the institute.
+     */
+    acquisitionPrice?: number;
+}
+
+/**
  * A connection used in the client to contact the server.
  */
 export interface Connection {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
         "lib": ["es7", "dom"],
         "emitDecoratorMetadata": true,
         "sourceMap": true,
-        "resolveJsonModule": true
+        "resolveJsonModule": true,
+        "skipLibCheck": true
     }
 }


### PR DESCRIPTION
## Summary
- add MT535 parser and request/response segments to support holdings retrieval
- expose client API and CLI commands for fetching balances and depot holdings
- extend documentation and tests to cover holdings parsing and cli usage

## Testing
- yarn --cwd packages/fints test
- yarn --cwd packages/fints-cli build

------
https://chatgpt.com/codex/tasks/task_b_68cf273c0eb0833196fd1510965b118f