### PR TITLE
Add TAN login completion helper

### DIFF
--- a/packages/fints/README.md
+++ b/packages/fints/README.md
@@ -28,6 +28,25 @@ const statements = await client.statements(accounts[0], startDate, endDate);
 console.info(statements); // List of all statements with transactions in specified date range.
 ```
 
+### Handling login TAN challenges
+
+Some banks require a TAN as part of the login dialog. When that happens the library raises a `TanRequiredError`. You can
+complete the login by submitting the TAN and continue working with the returned dialog:
+
+```typescript
+import { TanRequiredError } from "fints";
+
+try {
+    const accounts = await client.accounts();
+} catch (error) {
+    if (error instanceof TanRequiredError) {
+        const dialog = await client.completeLogin(error.dialog, error.transactionReference, "123456");
+        const accounts = await client.accounts(dialog);
+        await dialog.end();
+    }
+}
+```
+
 [Further code examples](README_advanced_usage.md)
 
 ## Features

--- a/packages/fints/src/__tests__/test-client.ts
+++ b/packages/fints/src/__tests__/test-client.ts
@@ -1,0 +1,66 @@
+import { Client } from "../client";
+import { Dialog, DialogConfig } from "../dialog";
+import { Segment, HKTAN } from "../segments";
+import { Request } from "../request";
+import { TanMethod } from "../tan-method";
+
+class TestClient extends Client {
+    constructor(private readonly baseConfig: DialogConfig, private readonly mockConnection: any) {
+        super();
+    }
+
+    protected createDialog(dialogConfig?: DialogConfig): Dialog {
+        const config = dialogConfig ? dialogConfig : this.baseConfig;
+        return new Dialog(config, this.mockConnection);
+    }
+
+    protected createRequest(dialog: Dialog, segments: Segment<any>[], tan?: string): Request {
+        return new Request({
+            blz: dialog.blz,
+            name: dialog.name,
+            pin: dialog.pin,
+            systemId: dialog.systemId,
+            dialogId: dialog.dialogId,
+            msgNo: dialog.msgNo,
+            segments,
+            tanMethods: dialog.tanMethods,
+            tan,
+        });
+    }
+}
+
+describe("Client", () => {
+    const baseConfig: DialogConfig = { blz: "12345678", name: "user", pin: "secret", systemId: "1" } as DialogConfig;
+
+    test("completeLogin sends a follow-up TAN request and returns the updated dialog", async () => {
+        const connection = {
+            send: jest.fn().mockResolvedValue({
+                success: true,
+                returnValues: () => new Map(),
+                dialogId: "9999",
+            }),
+        };
+        const client = new TestClient(baseConfig, connection as any);
+        const savedDialog = new Dialog(baseConfig, connection as any);
+        savedDialog.hktanVersion = 7;
+        const tanMethod = new TanMethod(6);
+        tanMethod.name = "photoTAN";
+        savedDialog.tanMethods = [tanMethod];
+        savedDialog.msgNo = 1;
+        savedDialog.dialogId = "13579";
+
+        const resumedDialog = await client.completeLogin(savedDialog, "ref123", "987654");
+
+        expect(connection.send).toHaveBeenCalledTimes(1);
+        const request = connection.send.mock.calls[0][0] as Request;
+        expect(request.tan).toBe("987654");
+        expect(request.msgNo).toBe(2);
+        expect(request.segments).toHaveLength(1);
+        const hktan = request.segments[0] as HKTAN;
+        expect(hktan.process).toBe("2");
+        expect(hktan.aref).toBe("ref123");
+        expect(resumedDialog).toBeInstanceOf(Dialog);
+        expect(resumedDialog.dialogId).toBe("9999");
+        expect(resumedDialog.msgNo).toBe(3);
+    });
+});

--- a/packages/fints/src/__tests__/test-dialog.ts
+++ b/packages/fints/src/__tests__/test-dialog.ts
@@ -38,9 +38,18 @@ describe("Dialog", () => {
                 success: true,
                 returnValues: () => new Map([["0030", { message: "TAN required" }]]),
                 findSegment: () => hitan,
+                dialogId: "4711",
             }),
         };
         const dialog = new Dialog(baseConfig, connection as any);
-        await expect(dialog.send(new Request(baseConfig))).rejects.toBeInstanceOf(TanRequiredError);
+        expect.assertions(3);
+        try {
+            await dialog.send(new Request(baseConfig));
+            throw new Error("Expected TAN challenge to trigger TanRequiredError.");
+        } catch (error) {
+            expect(error).toBeInstanceOf(TanRequiredError);
+            expect((error as TanRequiredError).dialog.dialogId).toBe("4711");
+            expect(dialog.dialogId).toBe("4711");
+        }
     });
 });

--- a/packages/fints/src/client.ts
+++ b/packages/fints/src/client.ts
@@ -26,14 +26,20 @@ export abstract class Client {
     /**
      * Fetch a list of all SEPA accounts accessible by the user.
      *
+     * @param existingDialog Optionally reuse an already authenticated dialog instance.
      * @return An array of all SEPA accounts.
      */
-    public async accounts(): Promise<SEPAAccount[]> {
-        const dialog = this.createDialog();
-        await dialog.sync();
-        await dialog.init();
+    public async accounts(existingDialog?: Dialog): Promise<SEPAAccount[]> {
+        const dialog = existingDialog ?? this.createDialog();
+        const shouldInitializeDialog = !existingDialog;
+        if (shouldInitializeDialog) {
+            await dialog.sync();
+            await dialog.init();
+        }
         const response = await dialog.send(this.createRequest(dialog, [new HKSPA({ segNo: 3 })]));
-        await dialog.end();
+        if (shouldInitializeDialog) {
+            await dialog.end();
+        }
         const hispa = response.findSegment(HISPA);
 
         hispa.accounts.map((account) => {
@@ -57,13 +63,17 @@ export abstract class Client {
      * Fetch the balance for a SEPA account.
      *
      * @param account The SEPA account to fetch the balance for.
+     * @param existingDialog Optionally reuse an already authenticated dialog instance.
      *
      * @return The balance of the given SEPA account.
      */
-    public async balance(account: SEPAAccount): Promise<Balance> {
-        const dialog = this.createDialog();
-        await dialog.sync();
-        await dialog.init();
+    public async balance(account: SEPAAccount, existingDialog?: Dialog): Promise<Balance> {
+        const dialog = existingDialog ?? this.createDialog();
+        const shouldInitializeDialog = !existingDialog;
+        if (shouldInitializeDialog) {
+            await dialog.sync();
+            await dialog.init();
+        }
         let touchdowns: Map<string, string>;
         let touchdown: string | undefined;
         const responses: Response[] = [];
@@ -81,7 +91,9 @@ export abstract class Client {
             touchdown = touchdowns.get("HKSAL");
             responses.push(response);
         } while (touchdown);
-        await dialog.end();
+        if (shouldInitializeDialog) {
+            await dialog.end();
+        }
         const segments: HISAL[] = responses.reduce((result, response: Response) => {
             result.push(...response.findSegments(HISAL));
             return result;
@@ -104,16 +116,22 @@ export abstract class Client {
      * Fetch the list of holdings for a depot account.
      *
      * @param account The account to fetch holdings for.
+     * @param existingDialog Optionally reuse an already authenticated dialog instance.
      *
      * @return A list of holdings contained in the depot.
      */
-    public async holdings(account: SEPAAccount): Promise<Holding[]> {
-        const dialog = this.createDialog();
-        await dialog.sync();
+    public async holdings(account: SEPAAccount, existingDialog?: Dialog): Promise<Holding[]> {
+        const dialog = existingDialog ?? this.createDialog();
+        const shouldInitializeDialog = !existingDialog;
+        if (shouldInitializeDialog) {
+            await dialog.sync();
+        }
         if (!dialog.hiwpdsVersion) {
             throw new Error("Holdings are not supported by this bank.");
         }
-        await dialog.init();
+        if (shouldInitializeDialog) {
+            await dialog.init();
+        }
         let touchdowns: Map<string, string>;
         let touchdown: string | undefined;
         const responses: Response[] = [];
@@ -131,7 +149,9 @@ export abstract class Client {
             touchdown = touchdowns.get("HKWPD");
             responses.push(response);
         } while (touchdown);
-        await dialog.end();
+        if (shouldInitializeDialog) {
+            await dialog.end();
+        }
         const parser = new MT535Parser();
         return responses.reduce((result: Holding[], response: Response) => {
             response.findSegments(HIWPD).forEach((segment) => {
@@ -152,13 +172,22 @@ export abstract class Client {
      *
      * @param startDate The start of the range for which the statements should be fetched.
      * @param endDate The end of the range for which the statements should be fetched.
+     * @param existingDialog Optionally reuse an already authenticated dialog instance.
      *
      * @return A list of all statements in the specified range.
      */
-    public async statements(account: SEPAAccount, startDate?: Date, endDate?: Date): Promise<Statement[]> {
-        const dialog = this.createDialog();
-        await dialog.sync();
-        await dialog.init();
+    public async statements(
+        account: SEPAAccount,
+        startDate?: Date,
+        endDate?: Date,
+        existingDialog?: Dialog,
+    ): Promise<Statement[]> {
+        const dialog = existingDialog ?? this.createDialog();
+        const shouldInitializeDialog = !existingDialog;
+        if (shouldInitializeDialog) {
+            await dialog.sync();
+            await dialog.init();
+        }
         const segments: Segment<any>[] = [];
         segments.push(
             new HKKAZ({
@@ -181,7 +210,7 @@ export abstract class Client {
                 }),
             );
         }
-        return await this.sendStatementRequest(dialog, segments);
+        return await this.sendStatementRequest(dialog, segments, undefined, shouldInitializeDialog);
     }
 
     /**
@@ -214,7 +243,44 @@ export abstract class Client {
         return await this.sendStatementRequest(dialog, segments, tan);
     }
 
-    private async sendStatementRequest(dialog: Dialog, segments: Segment<any>[], tan?: string): Promise<Statement[]> {
+    /**
+     * Complete a login flow that has been interrupted by a TAN challenge.
+     *
+     * @param savedDialog The dialog data returned with the {@link TanRequiredError}.
+     * @param transactionReference The transaction reference from the challenge message.
+     * @param tan The TAN that should be used to authorize the login.
+     *
+     * @return A dialog that can be reused to continue the original request. The caller is responsible for ending the dialog
+     * once no further messages should be sent.
+     */
+    public async completeLogin(
+        savedDialog: DialogConfig,
+        transactionReference: string,
+        tan: string,
+    ): Promise<Dialog> {
+        const dialog = this.createDialog(savedDialog);
+        dialog.msgNo = dialog.msgNo + 1;
+        const version = dialog.hktanVersion >= 7 ? 7 : 6;
+        const segments: Segment<any>[] = [
+            new HKTAN({
+                segNo: 3,
+                version,
+                process: "2",
+                segmentReference: "HKIDN",
+                aref: transactionReference,
+                medium: dialog.tanMethods[0].name,
+            }),
+        ];
+        await dialog.send(this.createRequest(dialog, segments, tan));
+        return dialog;
+    }
+
+    private async sendStatementRequest(
+        dialog: Dialog,
+        segments: Segment<any>[],
+        tan?: string,
+        shouldEndDialog = true,
+    ): Promise<Statement[]> {
         let touchdowns: Map<string, string>;
         let touchdown: string;
         const responses: Response[] = [];
@@ -225,7 +291,9 @@ export abstract class Client {
             touchdown = touchdowns.get("HKKAZ");
             responses.push(response);
         } while (touchdown);
-        await dialog.end();
+        if (shouldEndDialog) {
+            await dialog.end();
+        }
         const responseSegments: HIKAZ[] = responses.reduce((result, response: Response) => {
             result.push(...response.findSegments(HIKAZ));
             return result;
@@ -245,13 +313,17 @@ export abstract class Client {
      * Fetch a list of standing orders for the given account.
      *
      * @param account The account to fetch standing orders for.
+     * @param existingDialog Optionally reuse an already authenticated dialog instance.
      *
      * @return A list of all standing orders for the given account.
      */
-    public async standingOrders(account: SEPAAccount): Promise<StandingOrder[]> {
-        const dialog = this.createDialog();
-        await dialog.sync();
-        await dialog.init();
+    public async standingOrders(account: SEPAAccount, existingDialog?: Dialog): Promise<StandingOrder[]> {
+        const dialog = existingDialog ?? this.createDialog();
+        const shouldInitializeDialog = !existingDialog;
+        if (shouldInitializeDialog) {
+            await dialog.sync();
+            await dialog.init();
+        }
         let touchdowns: Map<string, string>;
         let touchdown: string;
         const responses: Response[] = [];
@@ -270,7 +342,9 @@ export abstract class Client {
             touchdown = touchdowns.get("HKCDB");
             responses.push(response);
         } while (touchdown);
-        await dialog.end();
+        if (shouldInitializeDialog) {
+            await dialog.end();
+        }
         const segments: HICDB[] = responses.reduce((result, response: Response) => {
             result.push(...response.findSegments(HICDB));
             return result;

--- a/packages/fints/src/dialog.ts
+++ b/packages/fints/src/dialog.ts
@@ -171,6 +171,7 @@ export class Dialog extends DialogConfig {
         request.tanMethods = this.tanMethods;
 
         const response = await this.connection.send(request);
+        this.dialogId = response.dialogId;
         if (!response.success) {
             throw new ResponseError(response);
         }


### PR DESCRIPTION
## Summary
- allow account, balance, holdings, statement, and standing order calls to reuse an already authenticated dialog
- add a `completeLogin` helper that finishes TAN-protected logins and verify it with unit tests
- keep the dialog identifier when TAN challenges are raised and document how to complete login TAN flows

## Testing
- yarn lint *(fails: command not found: tslint)*
- yarn workspace fints test *(fails: ts-jest missing peer dependency `jest-util` in the provided environment)*

------
https://chatgpt.com/codex/tasks/task_b_68cf3d66976c8331b86dbee6ede7984e